### PR TITLE
Add multi-browser cookie support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Monitor **Claude Code** and **OpenAI Codex CLI** usage directly in your Waybar status bar.
 
-This tool displays your AI coding assistant usage limits in real-time by reading browser cookies from Chrome. No API keys needed!
+This tool displays your AI coding assistant usage limits in real-time by reading browser cookies (Chrome by default). No API keys needed!
 
 ## What This Monitors
 
@@ -19,7 +19,7 @@ This tool displays your AI coding assistant usage limits in real-time by reading
 - ⏰ Countdown timer until quota reset
 - 🚦 Color-coded warnings (green → yellow → red)
 - 🔄 Click to refresh instantly
-- 🍪 Uses browser cookies (Chrome only) - no API key needed
+- 🍪 Uses browser cookies (Chrome by default, configurable) - no API key needed
 - 🎯 Special states: "Ready" (unused) and "Pause" (quota exhausted)
 - 🔁 Auto-retry on network errors
 
@@ -61,6 +61,10 @@ codex-usage
 # Waybar JSON output
 claude-usage --waybar
 codex-usage --waybar
+
+# Use a specific browser (repeatable, tried in order)
+claude-usage --browser chromium --browser brave
+codex-usage --browser chromium
 ```
 
 In development mode:
@@ -140,7 +144,7 @@ pkill waybar && waybar &
 
 For **development mode**, use:
 ```jsonc
-"exec": "uv run --directory /path/to/waybar-ai-usage python claude.py --waybar",
+"exec": "uv run --directory /path/to/waybar-ai-usage python claude.py --waybar --browser chromium",
 ```
 
 ## Display States
@@ -156,7 +160,7 @@ For **development mode**, use:
 
 ## Requirements
 
-- **Chrome browser** with active login to:
+- **Chrome browser** (default) or another supported browser with active login to:
   - [Claude.ai](https://claude.ai) for Claude Code monitoring
   - [ChatGPT](https://chatgpt.com) for Codex CLI monitoring
 - **Python 3.11+**
@@ -166,14 +170,14 @@ For **development mode**, use:
 
 ### "Cookie read failed" Error
 
-Make sure you're logged into Claude/ChatGPT in Chrome:
+Make sure you're logged into Claude/ChatGPT in your chosen browser:
 
 ```bash
 # Test Claude cookies
-python -c "import browser_cookie3; print(list(browser_cookie3.chrome(domain_name='claude.ai')))"
+python -c "import browser_cookie3; print(list(browser_cookie3.chromium(domain_name='claude.ai')))"
 
 # Test ChatGPT cookies
-python -c "import browser_cookie3; print(list(browser_cookie3.chrome(domain_name='chatgpt.com')))"
+python -c "import browser_cookie3; print(list(browser_cookie3.chromium(domain_name='chatgpt.com')))"
 ```
 
 ### "403 Forbidden" or "Net Err"
@@ -185,16 +189,11 @@ python -c "import browser_cookie3; print(list(browser_cookie3.chrome(domain_name
 
 ### Using Other Browsers
 
-Currently **only Chrome is supported**. To add support for other browsers, you'll need to modify the code:
+You can select browsers in order using `--browser` (repeatable). Without it, the default order is: `chrome`, `chromium`, `brave`, `edge`, `firefox`.
 
-```python
-# In claude.py and codex.py, change:
-browser_cookie3.chrome(domain_name="...")
-
-# To one of:
-browser_cookie3.chromium(domain_name="...")
-browser_cookie3.firefox(domain_name="...")
-browser_cookie3.brave(domain_name="...")
+```bash
+claude-usage --browser chromium --browser brave
+codex-usage --browser chromium
 ```
 
 ## Project Structure
@@ -216,7 +215,7 @@ waybar-ai-usage/
 
 ## How It Works
 
-1. **Cookie Extraction**: Uses `browser_cookie3` to read authentication cookies from Chrome
+1. **Cookie Extraction**: Uses `browser_cookie3` to read authentication cookies from your chosen browser
 2. **API Requests**: Makes authenticated requests to Claude.ai and ChatGPT APIs using `curl_cffi`
 3. **Usage Parsing**: Extracts usage percentages and reset times from API responses
 4. **Waybar Output**: Formats data as JSON for Waybar's custom module

--- a/codex.py
+++ b/codex.py
@@ -4,12 +4,10 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Dict
 
 from curl_cffi import requests
-import browser_cookie3
 
-from common import parse_window_direct, format_eta
+from common import format_eta, load_cookies, parse_window_direct
 
 
 # ================= Configuration =================
@@ -29,10 +27,9 @@ ICON_PATH = SCRIPT_DIR / "assets" / "codex.svg"
 
 # ================= Network Logic =================
 
-def get_codex_usage() -> dict:
+def get_codex_usage(browsers: list[str] | None = None) -> dict:
     try:
-        cj = browser_cookie3.chrome(domain_name="chatgpt.com")
-        cookies_dict = {c.name: c.value for c in cj}
+        cookies_dict, _browser = load_cookies("chatgpt.com", browsers)
     except Exception as e:
         raise RuntimeError(f"Failed to read browser cookies: {e}")
 
@@ -184,10 +181,15 @@ def print_cli(usage: dict) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--waybar", action="store_true")
+    parser.add_argument(
+        "--browser",
+        action="append",
+        help="Browser cookie source to try (repeatable). Example: --browser chromium",
+    )
     args = parser.parse_args()
 
     try:
-        usage = get_codex_usage()
+        usage = get_codex_usage(args.browser)
     except Exception as e:
         if args.waybar:
             err_msg = str(e)

--- a/waybar-config-example.jsonc
+++ b/waybar-config-example.jsonc
@@ -10,6 +10,8 @@
     // After 'uv tool install waybar-ai-usage':
     // IMPORTANT: Use full path to work with systemd-launched Waybar
     "exec": "~/.local/bin/claude-usage --waybar",
+    // Example for Chromium:
+    // "exec": "~/.local/bin/claude-usage --waybar --browser chromium",
 
     // Or for development mode:
     // "exec": "uv run --directory /home/YOUR_USER/Codes/waybar-ai-usage python claude.py --waybar",
@@ -27,6 +29,8 @@
     // After 'uv tool install waybar-ai-usage':
     // IMPORTANT: Use full path to work with systemd-launched Waybar
     "exec": "~/.local/bin/codex-usage --waybar",
+    // Example for Chromium:
+    // "exec": "~/.local/bin/codex-usage --waybar --browser chromium",
 
     // Or for development mode:
     // "exec": "uv run --directory /home/YOUR_USER/Codes/waybar-ai-usage python codex.py --waybar",


### PR DESCRIPTION
## Summary
- add shared cookie loader that tries multiple browsers in order
- add  flag to claude/codex CLIs (repeatable)
- update README and Waybar example config with browser selection

## Testing
- not run (CLI requires live session cookies)
