### PR TITLE
Feature/zen balance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Waybar AI Usage
 
-Monitor **Claude Code**, **OpenAI Codex CLI**, and **GitHub Copilot** usage directly in your Waybar status bar.
+Monitor **Claude Code**, **OpenAI Codex CLI**, **GitHub Copilot**, and **OpenCode Zen** usage directly in your Waybar status bar.
 
 ![showcase](https://github.com/user-attachments/assets/13e8a4a1-6778-484f-8a37-cba238aefea5)
 
@@ -17,6 +17,10 @@ This tool displays your AI coding assistant usage limits in real-time by reading
 - **GitHub Copilot**: Monthly premium request quota (Pro/Pro+)
   - Requests consumed vs. included quota (default: 300)
   - Countdown to monthly reset (1st of month, 00:00 UTC)
+- **OpenCode Zen**: Pay-as-you-go balance for curated coding models
+  - Current account balance in USD
+  - Color-coded warnings when balance is low
+  - No API key needed - uses browser cookies
 
 ## Features
 
@@ -99,6 +103,23 @@ copilot-usage          # Shows used/quota in terminal
 copilot-usage --waybar # Shows Waybar JSON
 ```
 
+## OpenCode Zen Setup
+
+Unlike Claude and Codex which have usage windows, **Zen** shows your current pay-as-you-go balance.
+
+### 1. Login to OpenCode
+
+Make sure you're logged into [opencode.ai](https://opencode.ai) in your Chrome/Chromium browser.
+
+### 2. Test It
+
+```bash
+zen-balance          # Shows balance in terminal
+zen-balance --waybar # Shows Waybar JSON
+```
+
+No configuration needed - it uses browser cookies just like Claude and Codex!
+
 ## Usage
 
 ### Command Line
@@ -133,10 +154,14 @@ codex-usage
 copilot-usage
 copilot-usage --config ~/.config/waybar-ai-usage/copilot.conf  # custom config path
 
+# OpenCode Zen balance
+zen-balance
+
 # Waybar JSON output
 claude-usage --waybar
 codex-usage --waybar
 copilot-usage --waybar
+zen-balance --waybar
 
 # Use a specific browser (repeatable, tried in order)
 claude-usage --browser chromium --browser brave
@@ -313,6 +338,7 @@ The first example will display:
   to:
   - [Claude.ai](https://claude.ai) for Claude Code monitoring
   - [ChatGPT](https://chatgpt.com) for Codex CLI monitoring
+  - [OpenCode](https://opencode.ai) for Zen balance monitoring
 - **Python 3.11+**
 - **uv** package manager
   ([installation guide](https://docs.astral.sh/uv/getting-started/installation/))
@@ -358,6 +384,7 @@ waybar-ai-usage/
 ├── claude.py                     # Claude Code usage monitor
 ├── codex.py                      # OpenAI Codex CLI usage monitor
 ├── copilot.py                    # GitHub Copilot premium request monitor
+├── zen.py                        # OpenCode Zen balance monitor
 ├── pyproject.toml                # Project metadata and dependencies
 ├── waybar-config-example.jsonc   # Template used by setup
 ├── waybar-style-example.css      # Template used by setup
@@ -388,6 +415,7 @@ Contributions are welcome! Areas for improvement:
 - [x] Better UX for setup/cleanup (preview changes, restore helper)
 - [x] Caching mechanism to reduce API calls (v0.4.0+)
 - [x] GitHub Copilot premium request monitoring (v0.5.0+)
+- [x] OpenCode Zen balance monitoring
 - [ ] Better error messages
 - [ ] More examples and screenshots
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "waybar-ai-usage"
 version = "0.5.0"
-description = "Monitor Claude, ChatGPT, and GitHub Copilot usage in Waybar"
+description = "Monitor Claude, ChatGPT, GitHub Copilot, and OpenCode Zen usage in Waybar"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
-keywords = ["waybar", "claude", "chatgpt", "openai", "copilot", "github", "usage", "monitor"]
+keywords = ["waybar", "claude", "chatgpt", "openai", "copilot", "github", "usage", "monitor", "opencode", "zen"]
 authors = [
     { name = "NihilDigit" }
 ]
@@ -33,6 +33,7 @@ Issues = "https://github.com/NihilDigit/waybar-ai-usage/issues"
 claude-usage = "claude:main"
 codex-usage = "codex:main"
 copilot-usage = "copilot:main"
+zen-balance = "zen:main"
 waybar-ai-usage = "waybar_ai_usage:main"
 
 [build-system]
@@ -40,7 +41,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["claude.py", "codex.py", "copilot.py", "common.py", "waybar_ai_usage.py"]
+packages = ["claude.py", "codex.py", "copilot.py", "zen.py", "common.py", "waybar_ai_usage.py"]
 
 [dependency-groups]
 dev = []

--- a/waybar_ai_usage.py
+++ b/waybar_ai_usage.py
@@ -66,6 +66,19 @@ TEMPLATE_CONFIG = """// Waybar Configuration Example
     "tooltip": true,
     "on-click": "pkill -RTMIN+10 waybar",  // Click to refresh immediately
     "signal": 10  // Refresh when receiving signal 10
+  },
+
+  // OpenCode Zen Balance Monitor
+  "custom/zen-balance": {
+    // Uses browser cookies - no API key needed
+    "exec": "~/.local/bin/zen-balance --waybar",
+
+    "return-type": "json",
+    "interval": 120,  // Refresh every 2 minutes
+    "format": "{}",
+    "tooltip": true,
+    "on-click": "pkill -RTMIN+11 waybar",  // Click to refresh immediately
+    "signal": 11  // Refresh when receiving signal 11
   }
 }
 """
@@ -156,10 +169,40 @@ TEMPLATE_STYLE = """/* Claude Code Usage Monitor Styling */
   color: #f38ba8;  /* Red: high usage (80-99%) */
 }
 
+/* OpenCode Zen Balance Monitor Styling */
+#custom-zen-balance {
+  padding: 0 8px;
+  margin: 0 4px;
+  border-radius: 4px;
+  background: transparent;
+  font-family: 'Adwaita Mono', monospace;
+  font-size: 11px;
+  font-weight: 500;
+  transition: all 0.3s ease;
+}
+
+#custom-zen-balance:hover {
+  background: rgba(116, 170, 156, 0.15);
+}
+
+/* Color-coded by balance level */
+#custom-zen-balance.zen-high {
+  color: #a6e3a1;  /* Green: good balance (> $10) */
+}
+
+#custom-zen-balance.zen-medium {
+  color: #f9e2af;  /* Yellow: getting low ($5-10) */
+}
+
+#custom-zen-balance.zen-low {
+  color: #f38ba8;  /* Red: critically low (< $5) */
+}
+
 /* Error state (network failures, auth errors, etc.) */
 #custom-claude-usage.critical,
 #custom-codex-usage.critical,
-#custom-copilot-usage.critical {
+#custom-copilot-usage.critical,
+#custom-zen-balance.critical {
   color: #ff5555;
   background: rgba(255, 85, 85, 0.1);
 }
@@ -178,7 +221,9 @@ def _confirm_changes(paths: Iterable[Path]) -> bool:
 
 
 def _print_done() -> None:
-    print("Next step: restart Waybar to apply changes (e.g. `pkill waybar && waybar &`).")
+    print(
+        "Next step: restart Waybar to apply changes (e.g. `pkill waybar && waybar &`)."
+    )
 
 
 def _list_backups(path: Path) -> list[Path]:
@@ -191,7 +236,10 @@ def _pick_latest_backup(path: Path) -> Path | None:
 
 
 def _find_style_region(lines: list[str]) -> tuple[int, int] | None:
-    start_markers = ("/* Claude Code Usage Monitor Styling */", "/* AI Usage Monitor Styling */")
+    start_markers = (
+        "/* Claude Code Usage Monitor Styling */",
+        "/* AI Usage Monitor Styling */",
+    )
     end_marker = "/* Error state (network failures, auth errors, etc.) */"
     start_idx = None
     end_idx = None
@@ -246,7 +294,12 @@ def _remove_style_blocks(lines: list[str]) -> list[str]:
         start_idx, end_idx = region
         return lines[:start_idx] + lines[end_idx:]
 
-    targets = ("#custom-claude-usage", "#custom-codex-usage", "#custom-copilot-usage")
+    targets = (
+        "#custom-claude-usage",
+        "#custom-codex-usage",
+        "#custom-copilot-usage",
+        "#custom-zen-balance",
+    )
     out: list[str] = []
     skipping = False
     depth = 0
@@ -295,7 +348,7 @@ def _read_template(path: Path, fallback: str) -> str:
 
 
 def _resolve_exec_base() -> str:
-    binaries = ("claude-usage", "codex-usage", "copilot-usage")
+    binaries = ("claude-usage", "codex-usage", "copilot-usage", "zen-balance")
     if any(Path(f"/usr/bin/{b}").exists() for b in binaries):
         return "/usr/bin"
     if any(Path(f"~/.local/bin/{b}").expanduser().exists() for b in binaries):
@@ -311,7 +364,17 @@ def _remove_config(config_path: Path, style_path: Path, dry_run: bool) -> None:
         changed = False
         modules_left = config_data.get("modules-left")
         if isinstance(modules_left, list):
-            new_modules = [m for m in modules_left if m not in ("custom/claude-usage", "custom/codex-usage", "custom/copilot-usage")]
+            new_modules = [
+                m
+                for m in modules_left
+                if m
+                not in (
+                    "custom/claude-usage",
+                    "custom/codex-usage",
+                    "custom/copilot-usage",
+                    "custom/zen-balance",
+                )
+            ]
             if new_modules != modules_left:
                 config_data["modules-left"] = new_modules
                 changed = True
@@ -320,6 +383,9 @@ def _remove_config(config_path: Path, style_path: Path, dry_run: bool) -> None:
             changed = True
         if "custom/codex-usage" in config_data:
             config_data.pop("custom/codex-usage", None)
+            changed = True
+        if "custom/zen-balance" in config_data:
+            config_data.pop("custom/zen-balance", None)
             changed = True
         if "custom/copilot-usage" in config_data:
             config_data.pop("custom/copilot-usage", None)
@@ -355,7 +421,9 @@ def _remove_config(config_path: Path, style_path: Path, dry_run: bool) -> None:
         _print_done()
 
 
-def _apply_setup(config_path: Path, style_path: Path, browsers: list[str] | None, dry_run: bool) -> None:
+def _apply_setup(
+    config_path: Path, style_path: Path, browsers: list[str] | None, dry_run: bool
+) -> None:
     example_config = Path(__file__).with_name("waybar-config-example.jsonc")
     example_style = Path(__file__).with_name("waybar-style-example.css")
     style_lines = style_path.read_text().splitlines() if style_path.exists() else []
@@ -363,7 +431,9 @@ def _apply_setup(config_path: Path, style_path: Path, browsers: list[str] | None
     example_config_text = _read_template(example_config, TEMPLATE_CONFIG)
     example_style_text = _read_template(example_style, TEMPLATE_STYLE)
     exec_base = _resolve_exec_base()
-    example_config_data = json5.loads(example_config_text.replace("~/.local/bin", exec_base))
+    example_config_data = json5.loads(
+        example_config_text.replace("~/.local/bin", exec_base)
+    )
     example_style_lines = example_style_text.splitlines()
     css_region = _extract_style_region(example_style_lines)
 
@@ -379,7 +449,7 @@ def _apply_setup(config_path: Path, style_path: Path, browsers: list[str] | None
         config_data["modules-left"] = modules_left
         changed_config = True
 
-    for name in ("custom/claude-usage", "custom/codex-usage"):
+    for name in ("custom/claude-usage", "custom/codex-usage", "custom/zen-balance"):
         if name not in modules_left:
             modules_left.append(name)
             changed_config = True
@@ -390,22 +460,32 @@ def _apply_setup(config_path: Path, style_path: Path, browsers: list[str] | None
         modules_left.append("custom/copilot-usage")
         changed_config = True
 
-    for key in ("custom/claude-usage", "custom/codex-usage"):
+    for key in ("custom/claude-usage", "custom/codex-usage", "custom/zen-balance"):
         if key not in config_data and key in example_config_data:
             config_data[key] = example_config_data[key]
             changed_config = True
 
-    if copilot_conf.exists() and "custom/copilot-usage" not in config_data and "custom/copilot-usage" in example_config_data:
-        config_data["custom/copilot-usage"] = example_config_data["custom/copilot-usage"]
+    if (
+        copilot_conf.exists()
+        and "custom/copilot-usage" not in config_data
+        and "custom/copilot-usage" in example_config_data
+    ):
+        config_data["custom/copilot-usage"] = example_config_data[
+            "custom/copilot-usage"
+        ]
         changed_config = True
 
     if browsers:
         flags = " ".join(f"--browser {b}" for b in browsers)
-        for key in ("custom/claude-usage", "custom/codex-usage"):
+        for key in ("custom/claude-usage", "custom/codex-usage", "custom/zen-balance"):
             entry = config_data.get(key)
             if isinstance(entry, dict):
                 exec_cmd = entry.get("exec")
-                if isinstance(exec_cmd, str) and "--waybar" in exec_cmd and "--browser" not in exec_cmd:
+                if (
+                    isinstance(exec_cmd, str)
+                    and "--waybar" in exec_cmd
+                    and "--browser" not in exec_cmd
+                ):
                     entry["exec"] = exec_cmd.replace("--waybar", f"--waybar {flags}")
                     changed_config = True
 
@@ -597,14 +677,23 @@ def main() -> None:
 
     if args.command == "setup":
         if not args.yes and not args.dry_run:
-            if not _confirm_changes([args.config.expanduser(), args.style.expanduser()]):
+            if not _confirm_changes(
+                [args.config.expanduser(), args.style.expanduser()]
+            ):
                 print("Aborted.")
                 return
-        _apply_setup(args.config.expanduser(), args.style.expanduser(), args.browser, args.dry_run)
+        _apply_setup(
+            args.config.expanduser(),
+            args.style.expanduser(),
+            args.browser,
+            args.dry_run,
+        )
         return
     if args.command == "cleanup":
         if not args.yes and not args.dry_run:
-            if not _confirm_changes([args.config.expanduser(), args.style.expanduser()]):
+            if not _confirm_changes(
+                [args.config.expanduser(), args.style.expanduser()]
+            ):
                 print("Aborted.")
                 return
         _remove_config(args.config.expanduser(), args.style.expanduser(), args.dry_run)

--- a/zen.py
+++ b/zen.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""OpenCode Zen balance fetcher for Waybar
+
+Fetches current Zen balance from the OpenCode dashboard using browser cookies.
+Similar to the claude-usage and codex-usage widgets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+from curl_cffi import requests
+
+from common import get_cached_or_fetch, load_cookies
+
+
+# ==================== Configuration ====================
+
+ZEN_DOMAIN = "opencode.ai"
+ZEN_URL = "https://opencode.ai/zen"
+
+BASE_HEADERS = {
+    "Referer": "https://opencode.ai/zen",
+    "Origin": "https://opencode.ai",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+}
+
+CACHE_TTL = 120  # Cache for 120 seconds
+
+
+# ==================== Core Logic: Get Balance ====================
+
+
+def _parse_balance_from_html(html_content: str) -> float | None:
+    """Parse balance from HTML content using various patterns"""
+
+    # Pattern 1: Look for the specific data-slot="balance" structure with HTML comments
+    # <span data-slot="balance">...Current balance...<b>$<!--$-->19.43<!--/--></b></span>
+    balance_match = re.search(
+        r'data-slot="balance"[^>]*>.*?Current balance.*?<b>\$\s*<!--\$-->([0-9]+\.[0-9]{2})<!--/-->',
+        html_content,
+        re.DOTALL,
+    )
+    if balance_match:
+        return float(balance_match.group(1))
+
+    # Pattern 2: Look for balance with HTML comments (simpler pattern)
+    balance_match = re.search(
+        r"Current balance.*?\$\s*<!--\$-->([0-9]+\.[0-9]{2})<!--/-->",
+        html_content,
+        re.DOTALL,
+    )
+    if balance_match:
+        return float(balance_match.group(1))
+
+    # Pattern 3: Simple "Current balance $XX.XX" pattern
+    balance_match = re.search(
+        r"Current balance\s*\$\s*([0-9]+\.[0-9]{2})",
+        html_content,
+    )
+    if balance_match:
+        return float(balance_match.group(1))
+
+    return None
+
+
+def _fetch_zen_balance_uncached(browsers: list[str] | None = None) -> dict:
+    """Internal function to fetch Zen balance without caching"""
+    try:
+        cookies, _browser = load_cookies(ZEN_DOMAIN, browsers)
+    except Exception as e:
+        raise RuntimeError(f"Failed to read cookies: {e}")
+
+    # Try zen URL first - it redirects to the specific workspace
+    last_error = None
+    for attempt in range(2):
+        try:
+            resp = requests.get(
+                ZEN_URL,
+                cookies=cookies,
+                headers=BASE_HEADERS,
+                impersonate="chrome",
+                timeout=10,
+                allow_redirects=True,  # Follow redirects to specific workspace
+            )
+
+            if resp.status_code == 403:
+                raise RuntimeError(
+                    "403 Forbidden: Try updating browser_cookie3 or refresh the page in browser."
+                )
+
+            resp.raise_for_status()
+
+            # Parse the HTML to find the balance
+            html_content = resp.text
+
+            balance = _parse_balance_from_html(html_content)
+
+            if balance is not None:
+                return {"balance": balance, "currency": "USD"}
+            else:
+                raise RuntimeError(
+                    "Could not find balance. Please ensure you're logged into opencode.ai/zen in your browser."
+                )
+
+        except Exception as e:
+            last_error = e
+            if attempt == 0:  # First failure, retry
+                continue
+
+    # All attempts failed
+    raise RuntimeError(f"Request failed: {last_error}")
+
+
+def get_zen_balance(browsers: list[str] | None = None) -> dict:
+    """
+    Fetch Zen balance using curl_cffi to impersonate Chrome.
+    Uses file-based caching to prevent multiple Waybar instances from making
+    concurrent API requests.
+    """
+    return get_cached_or_fetch(
+        "zen-balance", lambda: _fetch_zen_balance_uncached(browsers), ttl=CACHE_TTL
+    )
+
+
+# ==================== Output: CLI / Waybar ====================
+
+
+def print_cli(balance_data: dict) -> None:
+    """Print balance to terminal (for debugging)."""
+    print(f"Zen Balance: ${balance_data['balance']:.2f} {balance_data['currency']}")
+
+
+def print_waybar(balance_data: dict) -> None:
+    """Print balance in JSON format for Waybar"""
+    balance = balance_data.get("balance", 0.0)
+
+    # Format the balance text
+    text = f"<span foreground='#DE7356'>ZEN</span> ${balance:.2f}"
+
+    # Determine status class based on balance
+    if balance < 5:
+        cls = "zen-low"  # Red: critically low
+    elif balance < 10:
+        cls = "zen-medium"  # Yellow: getting low
+    else:
+        cls = "zen-high"  # Green: good balance
+
+    # Build tooltip
+    tooltip = (
+        f"OpenCode Zen Balance\n"
+        f"━━━━━━━━━━━━━━━━━━\n"
+        f"Balance: ${balance:.2f} USD\n"
+        f"\n"
+        f"Click to refresh"
+    )
+
+    output = {
+        "text": text,
+        "tooltip": tooltip,
+        "class": cls,
+        "alt": f"${balance:.2f}",
+    }
+
+    print(json.dumps(output))
+
+
+# ==================== CLI Entry Point ====================
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch OpenCode Zen balance for Waybar or CLI"
+    )
+    parser.add_argument(
+        "--waybar",
+        action="store_true",
+        help="Output in JSON format for Waybar custom module",
+    )
+    parser.add_argument(
+        "--browser",
+        action="append",
+        help="Browser cookie source to try (repeatable). Example: --browser chromium",
+    )
+    args = parser.parse_args()
+
+    try:
+        balance_data = get_zen_balance(args.browser)
+    except Exception as e:
+        if args.waybar:
+            err_msg = str(e)
+            short_err = (
+                "Auth Err"
+                if "403" in err_msg
+                else "Net Err"
+                if "failed" in err_msg
+                else "Err"
+            )
+            print(
+                json.dumps(
+                    {
+                        "text": f"<span foreground='#ff5555'>ZEN {short_err}</span>",
+                        "tooltip": f"Error fetching Zen balance:\n{err_msg}\n\nMake sure you're logged into opencode.ai/zen",
+                        "class": "critical",
+                    }
+                )
+            )
+            sys.exit(0)
+        else:
+            print(f"[!] Critical Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    if args.waybar:
+        print_waybar(balance_data)
+    else:
+        print_cli(balance_data)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Add OpenCode Zen balance monitor (zen-balance)

This PR adds support for monitoring OpenCode Zen pay-as-you-go balance alongside existing Claude, Codex, and Copilot monitors.

How it works:

The zen-balance command works the same way as claude-usage and codex-usage - it authenticates using your browser cookies, so no API key is needed:

1. Authentication: Reads cookies from your Chrome/Chromium browser for `opencode.ai` domain using the shared `common.py` utilities
2. Request: Fetches the `/zen` endpoint with Chrome impersonation via curl_cffi
3. Redirect handling: The `/zen` URL redirects to your specific workspace URL (e.g., /zen/ws_xxxxx) - the tool follows this redirect automatically instead of requiring a hardcoded workspace URL
4. HTML parsing: Extracts the USD balance from the HTML response using regex patterns that look for the "Current balance $XX.XX" structure
5. Output: Returns JSON for Waybar with color-coded classes based on balance:
   - **zen-high** (green): > $10
   - **zen-medium** (yellow): $5-10  
   - **zen-low** (red): < $5

**Usage**:

`zen-balance`          # Terminal output
`zen-balance --waybar` # Waybar JSON format

Run `waybar-ai-usage setup` to automatically add the Zen module to your Waybar config and CSS.