### PR TITLE
feat: add Z.ai usage quota monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Mentioned in Awesome Codex CLI](https://awesome.re/mentioned-badge.svg)](https://github.com/RoggeOhta/awesome-codex-cli)
 
-Monitor **Claude Code**, **OpenAI Codex CLI**, **GitHub Copilot**, and **OpenCode Zen** usage directly in your Waybar status bar.
+Monitor **Claude Code**, **OpenAI Codex CLI**, **GitHub Copilot**, **OpenCode Zen**, and **Z.ai** usage directly in your Waybar status bar.
 
 ![showcase](https://github.com/user-attachments/assets/13e8a4a1-6778-484f-8a37-cba238aefea5)
 
@@ -23,6 +23,10 @@ This tool displays your AI coding assistant usage limits in real-time by reading
   - Current account balance in USD
   - Color-coded warnings when balance is low
   - No API key needed - uses browser cookies
+- **Z.ai**: Usage quota monitoring (GLM models)
+  - 5-hour token usage window (percentage + reset timer)
+  - Monthly tool quota (web search, web reader, ZRead)
+  - Uses API token from config file
 
 ## Features
 
@@ -122,6 +126,37 @@ zen-balance --waybar # Shows Waybar JSON
 
 No configuration needed - it uses browser cookies just like Claude and Codex!
 
+## Z.ai Setup
+
+Unlike Claude and Codex which use browser cookies, **Z.ai** uses an API token for authentication.
+
+### 1. Get Your API Token
+
+1. Go to [z.ai](https://z.ai) and log in
+2. Open DevTools (**F12**) > **Network** tab
+3. Find any request to `api.z.ai` and copy the `Authorization` header value (e.g. `Bearer eyJ...`)
+4. You only need the token part after `Bearer `
+
+### 2. Create the Config File
+
+```bash
+mkdir -p ~/.config/waybar-ai-usage
+```
+
+Create `~/.config/waybar-ai-usage/zai.conf`:
+
+```ini
+# Z.ai API token from browser DevTools
+ZAI_TOKEN=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+### 3. Test It
+
+```bash
+zai-usage          # Shows usage in terminal
+zai-usage --waybar # Shows Waybar JSON
+```
+
 ## Usage
 
 ### Command Line
@@ -159,11 +194,16 @@ copilot-usage --config ~/.config/waybar-ai-usage/copilot.conf  # custom config p
 # OpenCode Zen balance
 zen-balance
 
+# Z.ai usage quota
+zai-usage
+zai-usage --config ~/.config/waybar-ai-usage/zai.conf  # custom config path
+
 # Waybar JSON output
 claude-usage --waybar
 codex-usage --waybar
 copilot-usage --waybar
 zen-balance --waybar
+zai-usage --waybar
 
 # Use a specific browser (repeatable, tried in order)
 claude-usage --browser chromium --browser brave
@@ -341,6 +381,7 @@ The first example will display:
   - [Claude.ai](https://claude.ai) for Claude Code monitoring
   - [ChatGPT](https://chatgpt.com) for Codex CLI monitoring
   - [OpenCode](https://opencode.ai) for Zen balance monitoring
+- **Z.ai account** with API token for Z.ai usage monitoring (see [Z.ai Setup](#zai-setup))
 - **Python 3.11+**
 - **uv** package manager
   ([installation guide](https://docs.astral.sh/uv/getting-started/installation/))
@@ -387,6 +428,7 @@ waybar-ai-usage/
 ├── codex.py                      # OpenAI Codex CLI usage monitor
 ├── copilot.py                    # GitHub Copilot premium request monitor
 ├── zen.py                        # OpenCode Zen balance monitor
+├── zai.py                        # Z.ai usage quota monitor
 ├── pyproject.toml                # Project metadata and dependencies
 ├── waybar-config-example.jsonc   # Template used by setup
 ├── waybar-style-example.css      # Template used by setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "waybar-ai-usage"
 version = "0.6.3"
-description = "Monitor Claude, ChatGPT, GitHub Copilot, and OpenCode Zen usage in Waybar"
+description = "Monitor Claude, ChatGPT, GitHub Copilot, OpenCode Zen, and Z.ai usage in Waybar"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
-keywords = ["waybar", "claude", "chatgpt", "openai", "copilot", "github", "usage", "monitor", "opencode", "zen"]
+keywords = ["waybar", "claude", "chatgpt", "openai", "copilot", "github", "usage", "monitor", "opencode", "zen", "zai"]
 authors = [
     { name = "NihilDigit" }
 ]
@@ -34,6 +34,7 @@ claude-usage = "claude:main"
 codex-usage = "codex:main"
 copilot-usage = "copilot:main"
 zen-balance = "zen:main"
+zai-usage = "zai:main"
 waybar-ai-usage = "waybar_ai_usage:main"
 
 [build-system]
@@ -41,7 +42,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["claude.py", "codex.py", "copilot.py", "zen.py", "common.py", "waybar_ai_usage.py"]
+packages = ["claude.py", "codex.py", "copilot.py", "zen.py", "zai.py", "common.py", "waybar_ai_usage.py"]
 
 [dependency-groups]
 dev = []

--- a/waybar-config-example.jsonc
+++ b/waybar-config-example.jsonc
@@ -67,5 +67,18 @@
     "tooltip": true,
     "on-click": "pkill -RTMIN+11 waybar",  // Click to refresh immediately
     "signal": 11  // Refresh when receiving signal 11
+  },
+
+  // Z.ai Usage Quota Monitor
+  "custom/zai-usage": {
+    // Requires ~/.config/waybar-ai-usage/zai.conf with ZAI_TOKEN=eyJ...
+    "exec": "~/.local/bin/zai-usage --waybar",
+
+    "return-type": "json",
+    "interval": 120,  // Refresh every 2 minutes
+    "format": "{}",
+    "tooltip": true,
+    "on-click": "pkill -RTMIN+12 waybar",  // Click to refresh immediately
+    "signal": 12  // Refresh when receiving signal 12
   }
 }

--- a/waybar-style-example.css
+++ b/waybar-style-example.css
@@ -113,11 +113,40 @@
   color: #f38ba8;  /* Red: critically low (< $5) */
 }
 
+/* Z.ai Usage Quota Monitor Styling */
+#custom-zai-usage {
+  padding: 0 8px;
+  margin: 0 4px;
+  border-radius: 4px;
+  background: transparent;
+  font-family: 'Adwaita Mono', monospace;
+  font-size: 11px;
+  font-weight: 500;
+  transition: all 0.3s ease;
+}
+
+#custom-zai-usage:hover {
+  background: rgba(18, 110, 244, 0.15);
+}
+
+#custom-zai-usage.zai-low {
+  color: #a6e3a1;  /* Green: low usage (0-49%) */
+}
+
+#custom-zai-usage.zai-mid {
+  color: #f9e2af;  /* Yellow: medium usage (50-79%) */
+}
+
+#custom-zai-usage.zai-high {
+  color: #f38ba8;  /* Red: high usage (80-100%) */
+}
+
 /* Error state (network failures, auth errors, etc.) */
 #custom-claude-usage.critical,
 #custom-codex-usage.critical,
 #custom-copilot-usage.critical,
-#custom-zen-balance.critical {
+#custom-zen-balance.critical,
+#custom-zai-usage.critical {
   color: #ff5555;
   background: rgba(255, 85, 85, 0.1);
 }

--- a/waybar_ai_usage.py
+++ b/waybar_ai_usage.py
@@ -15,6 +15,7 @@ MODULES = [
     {"key": "custom/codex-usage", "name": "Codex CLI", "desc": "usage limits", "default": True},
     {"key": "custom/copilot-usage", "name": "GitHub Copilot", "desc": "premium requests", "default": "copilot.conf"},
     {"key": "custom/zen-balance", "name": "OpenCode Zen", "desc": "balance monitor", "default": False},
+    {"key": "custom/zai-usage", "name": "Z.ai", "desc": "usage quota", "default": "zai.conf"},
 ]
 
 TEMPLATE_CONFIG = """// Waybar Configuration Example
@@ -86,6 +87,19 @@ TEMPLATE_CONFIG = """// Waybar Configuration Example
     "tooltip": true,
     "on-click": "pkill -RTMIN+11 waybar",  // Click to refresh immediately
     "signal": 11  // Refresh when receiving signal 11
+  },
+
+  // Z.ai Usage Quota Monitor
+  "custom/zai-usage": {
+    // Requires ~/.config/waybar-ai-usage/zai.conf with ZAI_TOKEN=eyJ...
+    "exec": "~/.local/bin/zai-usage --waybar",
+
+    "return-type": "json",
+    "interval": 120,  // Refresh every 2 minutes
+    "format": "{}",
+    "tooltip": true,
+    "on-click": "pkill -RTMIN+12 waybar",  // Click to refresh immediately
+    "signal": 12  // Refresh when receiving signal 12
   }
 }
 """
@@ -205,11 +219,41 @@ TEMPLATE_STYLE = """/* Claude Code Usage Monitor Styling */
   color: #f38ba8;  /* Red: critically low (< $5) */
 }
 
+/* Z.ai Usage Quota Monitor Styling */
+#custom-zai-usage {
+  padding: 0 8px;
+  margin: 0 4px;
+  border-radius: 4px;
+  background: transparent;
+  font-family: 'Adwaita Mono', monospace;
+  font-size: 11px;
+  font-weight: 500;
+  transition: all 0.3s ease;
+}
+
+#custom-zai-usage:hover {
+  background: rgba(18, 110, 244, 0.15);
+}
+
+/* Color-coded by usage level */
+#custom-zai-usage.zai-low {
+  color: #a6e3a1;  /* Green: low usage (0-49%) */
+}
+
+#custom-zai-usage.zai-mid {
+  color: #f9e2af;  /* Yellow: medium usage (50-79%) */
+}
+
+#custom-zai-usage.zai-high {
+  color: #f38ba8;  /* Red: high usage (80-100%) */
+}
+
 /* Error state (network failures, auth errors, etc.) */
 #custom-claude-usage.critical,
 #custom-codex-usage.critical,
 #custom-copilot-usage.critical,
-#custom-zen-balance.critical {
+#custom-zen-balance.critical,
+#custom-zai-usage.critical {
   color: #ff5555;
   background: rgba(255, 85, 85, 0.1);
 }
@@ -434,6 +478,8 @@ def _remove_style_blocks(lines: list[str]) -> list[str]:
         "#custom-codex-usage",
         "#custom-copilot-usage",
         "#custom-zen-balance",
+
+        "#custom-zai-usage",
     )
     out: list[str] = []
     skipping = False
@@ -483,7 +529,7 @@ def _read_template(path: Path, fallback: str) -> str:
 
 
 def _resolve_exec_base() -> str:
-    binaries = ("claude-usage", "codex-usage", "copilot-usage", "zen-balance")
+    binaries = ("claude-usage", "codex-usage", "copilot-usage", "zen-balance", "zai-usage")
     if any(Path(f"/usr/bin/{b}").exists() for b in binaries):
         return "/usr/bin"
     if any(Path(f"~/.local/bin/{b}").expanduser().exists() for b in binaries):
@@ -508,6 +554,7 @@ def _remove_config(config_path: Path, style_path: Path, dry_run: bool) -> None:
                     "custom/codex-usage",
                     "custom/copilot-usage",
                     "custom/zen-balance",
+                    "custom/zai-usage",
                 )
             ]
             if new_modules != modules_left:
@@ -524,6 +571,9 @@ def _remove_config(config_path: Path, style_path: Path, dry_run: bool) -> None:
             changed = True
         if "custom/copilot-usage" in config_data:
             config_data.pop("custom/copilot-usage", None)
+            changed = True
+        if "custom/zai-usage" in config_data:
+            config_data.pop("custom/zai-usage", None)
             changed = True
 
         if changed:

--- a/waybar_ai_usage.py
+++ b/waybar_ai_usage.py
@@ -478,7 +478,6 @@ def _remove_style_blocks(lines: list[str]) -> list[str]:
         "#custom-codex-usage",
         "#custom-copilot-usage",
         "#custom-zen-balance",
-
         "#custom-zai-usage",
     )
     out: list[str] = []

--- a/zai.py
+++ b/zai.py
@@ -5,7 +5,6 @@ import json
 import sys
 import urllib.request
 import urllib.error
-from datetime import datetime, timezone
 from pathlib import Path
 
 from common import format_eta, format_output, get_cached_or_fetch
@@ -110,14 +109,7 @@ def _format_tokens(value: int) -> str:
 def _format_ms_reset(ms: int | None) -> str:
     if not ms:
         return "??"
-    try:
-        reset_dt = datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
-        now = datetime.now(timezone.utc)
-        delta = reset_dt - now
-        secs = int(delta.total_seconds())
-    except Exception:
-        return "??"
-    return format_eta(None) if secs <= 0 else format_eta(reset_dt.isoformat())
+    return format_eta(ms // 1000)
 
 
 # ==================== Output: CLI / Waybar ====================
@@ -157,13 +149,12 @@ def print_waybar(
     pct = tl.get("percentage", 0) if tl else 0
     reset_str = _format_ms_reset(tl.get("nextResetTime")) if tl else "??"
 
-    is_unused = pct == 0 and tl and tl.get("remaining") is not None
-    window_not_started = pct == 0 and tl and tl.get("nextResetTime") is None
+    is_ready = pct == 0 and tl is not None
     is_exhausted = pct >= 100
 
     if is_exhausted:
         status = "Pause"
-    elif is_unused or window_not_started:
+    elif is_ready:
         status = "Ready"
     else:
         status = ""
@@ -215,7 +206,7 @@ def print_waybar(
             for d in ml.get("usageDetails", []):
                 code = d.get("modelCode", "?")
                 usage = d.get("usage", 0)
-                lines.append(f"  \u2022 {code:<12} {usage}")
+                lines.append(f"  \u2022 {code:<12} {_format_tokens(usage)}")
         lines.append("")
         lines.append("Click to Refresh")
         tooltip = "\n".join(lines)

--- a/zai.py
+++ b/zai.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone
+from pathlib import Path
+
+from common import format_eta, format_output, get_cached_or_fetch
+
+
+# ==================== Configuration ====================
+
+CONFIG_PATH = Path("~/.config/waybar-ai-usage/zai.conf").expanduser()
+ZAI_ICON = "Z"
+ZAI_COLOR = "#126EF4"
+API_BASE = "https://api.z.ai"
+QUOTA_URL = f"{API_BASE}/api/monitor/usage/quota/limit"
+MODEL_USAGE_URL = f"{API_BASE}/api/monitor/usage/model-usage"
+TOOL_USAGE_URL = f"{API_BASE}/api/monitor/usage/tool-usage"
+
+
+def load_zai_config(config_path: Path | None = None) -> dict:
+    path = config_path or CONFIG_PATH
+    config: dict = {"ZAI_TOKEN": None}
+
+    if not path.exists():
+        return config
+
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" in line:
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip()
+            if key == "ZAI_TOKEN":
+                config["ZAI_TOKEN"] = value
+
+    return config
+
+
+# ==================== Core Logic: Get Quota ====================
+
+
+def _api_get(url: str, token: str) -> dict:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "User-Agent": "waybar-ai-usage/zai",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        raise RuntimeError(f"HTTP {e.code}: {body}") from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"Network error: {e.reason}") from e
+
+
+def _fetch_zai_quota_uncached(token: str) -> dict:
+    data = _api_get(QUOTA_URL, token)
+
+    if not data.get("success"):
+        msg = data.get("msg", "Unknown error")
+        raise RuntimeError(f"API error: {msg}")
+
+    limits = data.get("data", {}).get("limits", [])
+
+    token_limit = None
+    time_limit = None
+
+    for item in limits:
+        if item.get("type") == "TOKENS_LIMIT":
+            token_limit = item
+        elif item.get("type") == "TIME_LIMIT":
+            time_limit = item
+
+    return {
+        "token_limit": token_limit,
+        "time_limit": time_limit,
+        "level": data.get("data", {}).get("level"),
+    }
+
+
+def get_zai_quota(token: str) -> dict:
+    return get_cached_or_fetch(
+        "zai",
+        lambda: _fetch_zai_quota_uncached(token),
+        ttl=120,
+    )
+
+
+# ==================== Helpers ====================
+
+
+def _format_tokens(value: int) -> str:
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.1f}M"
+    if value >= 1_000:
+        return f"{value / 1_000:.1f}K"
+    return str(value)
+
+
+def _format_ms_reset(ms: int | None) -> str:
+    if not ms:
+        return "??"
+    try:
+        reset_dt = datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
+        now = datetime.now(timezone.utc)
+        delta = reset_dt - now
+        secs = int(delta.total_seconds())
+    except Exception:
+        return "??"
+    return format_eta(None) if secs <= 0 else format_eta(reset_dt.isoformat())
+
+
+# ==================== Output: CLI / Waybar ====================
+
+
+def print_cli(quota: dict) -> None:
+    tl = quota.get("token_limit")
+    ml = quota.get("time_limit")
+
+    print(f"Z.ai Usage (level: {quota.get('level', '?')})")
+    print("-" * 50)
+
+    if tl:
+        pct = tl.get("percentage", 0)
+        reset = _format_ms_reset(tl.get("nextResetTime"))
+        print(f"5h Tokens : {pct}%  (Reset in {reset})")
+
+    if ml:
+        pct = ml.get("percentage", 0)
+        remaining = ml.get("remaining", 0)
+        reset = _format_ms_reset(ml.get("nextResetTime"))
+        print(f"Monthly Tools: {pct}% ({remaining} remaining)")
+        for d in ml.get("usageDetails", []):
+            code = d.get("modelCode", "?")
+            usage = d.get("usage", 0)
+            print(f"  - {code}: {usage}")
+
+
+def print_waybar(
+    quota: dict,
+    format_str: str | None = None,
+    tooltip_format: str | None = None,
+) -> None:
+    tl = quota.get("token_limit")
+    ml = quota.get("time_limit")
+
+    pct = tl.get("percentage", 0) if tl else 0
+    reset_str = _format_ms_reset(tl.get("nextResetTime")) if tl else "??"
+
+    is_unused = pct == 0 and tl and tl.get("remaining") is not None
+    is_exhausted = pct >= 100
+
+    if is_exhausted:
+        status = "Pause"
+    elif is_unused:
+        status = "Ready"
+    else:
+        status = ""
+
+    icon_styled = f"<span foreground='{ZAI_COLOR}' size='large'>{ZAI_ICON}</span>"
+    time_icon_styled = f"<span foreground='{ZAI_COLOR}' size='large'>\U000f051a</span>"
+
+    data = {
+        "icon": icon_styled,
+        "icon_plain": ZAI_ICON,
+        "time_icon": time_icon_styled,
+        "time_icon_plain": "\U000f051a",
+        "pct": pct,
+        "reset": reset_str,
+        "status": status,
+    }
+
+    if ml:
+        ml_pct = ml.get("percentage", 0)
+        ml_remaining = ml.get("remaining", 0)
+        ml_reset = _format_ms_reset(ml.get("nextResetTime"))
+        data["tools_pct"] = ml_pct
+        data["tools_remaining"] = ml_remaining
+        data["tools_reset"] = ml_reset
+
+    if format_str:
+        text = format_output(format_str, data)
+    else:
+        if status == "Pause":
+            text = f"{icon_styled} Pause"
+        elif status == "Ready":
+            text = f"{icon_styled} Ready"
+        else:
+            text = f"{icon_styled} {pct}% {time_icon_styled} {reset_str}"
+
+    if tooltip_format:
+        tooltip = format_output(tooltip_format, data)
+    else:
+        lines = ["Z.ai Usage", "\u2501" * 24]
+        if tl:
+            lines.append(f"5h Tokens : {pct}%  Reset: {reset_str}")
+        if ml:
+            ml_pct = ml.get("percentage", 0)
+            ml_remaining = ml.get("remaining", 0)
+            ml_reset = _format_ms_reset(ml.get("nextResetTime"))
+            lines.append(f"Tools      : {ml_pct}% ({ml_remaining} remaining)  Reset: {ml_reset}")
+            for d in ml.get("usageDetails", []):
+                code = d.get("modelCode", "?")
+                usage = d.get("usage", 0)
+                lines.append(f"  \u2022 {code}: {usage}")
+        lines.append("")
+        lines.append("Click to Refresh")
+        tooltip = "\n".join(lines)
+
+    if pct < 50:
+        cls = "zai-low"
+    elif pct < 80:
+        cls = "zai-mid"
+    else:
+        cls = "zai-high"
+
+    output = {
+        "text": text,
+        "tooltip": tooltip,
+        "class": cls,
+        "percentage": pct,
+    }
+    print(json.dumps(output))
+
+
+# ==================== CLI Entry Point ====================
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Show Z.ai usage in Waybar",
+    )
+    parser.add_argument(
+        "--waybar",
+        action="store_true",
+        help="Output in JSON format for Waybar custom module",
+    )
+    parser.add_argument(
+        "--format",
+        type=str,
+        help=(
+            "Custom format string for waybar text. Available: {icon}, {icon_plain}, "
+            "{pct}, {reset}, {status}, {tools_pct}, {tools_remaining}, {tools_reset}. "
+            "Example: '{icon_plain} {pct}%%'"
+        ),
+    )
+    parser.add_argument(
+        "--tooltip-format",
+        type=str,
+        help="Custom format string for tooltip. Uses same variables as --format.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=CONFIG_PATH,
+        help=f"Path to Z.ai config file (default: {CONFIG_PATH})",
+    )
+    args = parser.parse_args()
+
+    config = load_zai_config(args.config)
+    token = config["ZAI_TOKEN"]
+
+    if not token:
+        if args.waybar:
+            print(json.dumps({
+                "text": f"<span foreground='#ff5555'>{ZAI_ICON} No Token</span>",
+                "tooltip": (
+                    f"No ZAI_TOKEN found in {args.config}\n"
+                    f"1. Go to https://z.ai/manage-apikey/subscription\n"
+                    f"2. Open DevTools > Network\n"
+                    f"3. Find a request to api.z.ai and copy the Authorization header\n"
+                    f"4. Save as ZAI_TOKEN=eyJ... in {args.config}"
+                ),
+                "class": "critical",
+            }))
+            sys.exit(0)
+        else:
+            print(
+                f"[!] Error: No ZAI_TOKEN in {args.config}",
+                file=sys.stderr,
+            )
+            print(
+                f"    Create config: mkdir -p ~/.config/waybar-ai-usage",
+                file=sys.stderr,
+            )
+            print(
+                f"    Then add: ZAI_TOKEN=your_token_here",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    try:
+        quota = get_zai_quota(token)
+    except Exception as e:
+        if args.waybar:
+            err_msg = str(e)
+            is_auth = "401" in err_msg or "403" in err_msg
+            short_err = "Auth Err" if is_auth else "Net Err"
+            tooltip = f"Error fetching Z.ai quota:\n{err_msg}"
+            print(json.dumps({
+                "text": f"<span foreground='#ff5555'>{ZAI_ICON} {short_err}</span>",
+                "tooltip": tooltip,
+                "class": "critical",
+            }))
+            sys.exit(0)
+        else:
+            print(f"[!] Critical Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    if args.waybar:
+        print_waybar(quota, args.format, args.tooltip_format)
+    else:
+        print_cli(quota)
+
+
+if __name__ == "__main__":
+    main()

--- a/zai.py
+++ b/zai.py
@@ -18,8 +18,6 @@ ZAI_ICON = "Z"
 ZAI_COLOR = "#126EF4"
 API_BASE = "https://api.z.ai"
 QUOTA_URL = f"{API_BASE}/api/monitor/usage/quota/limit"
-MODEL_USAGE_URL = f"{API_BASE}/api/monitor/usage/model-usage"
-TOOL_USAGE_URL = f"{API_BASE}/api/monitor/usage/tool-usage"
 
 
 def load_zai_config(config_path: Path | None = None) -> dict:
@@ -160,11 +158,12 @@ def print_waybar(
     reset_str = _format_ms_reset(tl.get("nextResetTime")) if tl else "??"
 
     is_unused = pct == 0 and tl and tl.get("remaining") is not None
+    window_not_started = pct == 0 and tl and tl.get("nextResetTime") is None
     is_exhausted = pct >= 100
 
     if is_exhausted:
         status = "Pause"
-    elif is_unused:
+    elif is_unused or window_not_started:
         status = "Ready"
     else:
         status = ""
@@ -203,18 +202,20 @@ def print_waybar(
     if tooltip_format:
         tooltip = format_output(tooltip_format, data)
     else:
-        lines = ["Z.ai Usage", "\u2501" * 24]
+        lines = [
+            "Window     Used    Reset",
+            "\u2501" * 24,
+        ]
         if tl:
-            lines.append(f"5h Tokens : {pct}%  Reset: {reset_str}")
+            lines.append(f"Tokens     {pct:>3}%    {reset_str}")
         if ml:
             ml_pct = ml.get("percentage", 0)
-            ml_remaining = ml.get("remaining", 0)
             ml_reset = _format_ms_reset(ml.get("nextResetTime"))
-            lines.append(f"Tools      : {ml_pct}% ({ml_remaining} remaining)  Reset: {ml_reset}")
+            lines.append(f"Tools      {ml_pct:>3}%    {ml_reset}")
             for d in ml.get("usageDetails", []):
                 code = d.get("modelCode", "?")
                 usage = d.get("usage", 0)
-                lines.append(f"  \u2022 {code}: {usage}")
+                lines.append(f"  \u2022 {code:<12} {usage}")
         lines.append("")
         lines.append("Click to Refresh")
         tooltip = "\n".join(lines)
@@ -278,8 +279,8 @@ def main() -> None:
                 "text": f"<span foreground='#ff5555'>{ZAI_ICON} No Token</span>",
                 "tooltip": (
                     f"No ZAI_TOKEN found in {args.config}\n"
-                    f"1. Go to https://z.ai/manage-apikey/subscription\n"
-                    f"2. Open DevTools > Network\n"
+                    f"1. Go to https://z.ai and log in\n"
+                    f"2. Open DevTools (F12) > Network tab\n"
                     f"3. Find a request to api.z.ai and copy the Authorization header\n"
                     f"4. Save as ZAI_TOKEN=eyJ... in {args.config}"
                 ),


### PR DESCRIPTION
## Summary

- Add `zai.py` provider that monitors [Z.ai](https://z.ai) usage via the `api.z.ai/api/monitor/usage/quota/limit` endpoint
- Displays **5-hour token usage** in the Waybar bar with reset timer
- Shows **monthly tool quota** breakdown (search-prime, web-reader, zread) in the tooltip
- Uses token-based auth from `~/.config/waybar-ai-usage/zai.conf` (same pattern as Copilot module)
- Color-coded by usage level: green (`zai-low`), yellow (`zai-mid`), red (`zai-high`)

## Changes

| File | Change |
|------|--------|
| `zai.py` | New Z.ai provider module |
| `pyproject.toml` | Register `zai-usage` script entry point |
| `waybar_ai_usage.py` | Add Z.ai to MODULES, config template, style template, setup/cleanup |
| `waybar-config-example.jsonc` | Add Z.ai module block (signal 12) |
| `waybar-style-example.css` | Add Z.ai CSS styles |
| `README.md` | Add Z.ai to description, setup guide, usage examples |

## Setup

```bash
mkdir -p ~/.config/waybar-ai-usage
# Get token: z.ai > F12 > Network > copy Authorization header (eyJ...)
echo "ZAI_TOKEN=eyJ..." > ~/.config/waybar-ai-usage/zai.conf
zai-usage --waybar
```

## Auth Notes

Z.ai uses an HS512 JWT for API calls that is generated in JavaScript memory (not persisted to cookies or localStorage). Unlike Claude/Codex, browser auto-detection is not feasible, so config-file auth (like Copilot) is the only reliable approach.