### PR TITLE
feat: support org-managed Copilot usage fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Copilot uses a **GitHub Personal Access Token** instead of browser cookies.
 
 > **Note**: The **"Copilot"** permission scope is *not* the right one — you need **"Plan"**.
 >
-> This endpoint only works if your Copilot license is billed directly to your personal account (Copilot Pro/Pro+). If your license is managed by an organization, the data won't appear here.
+> This API endpoint only works if your Copilot license is billed directly to your personal account (Copilot Pro/Pro+). If your license is managed by an organization, `copilot-usage` will automatically fall back to reading the usage percentage from the authenticated Copilot settings page in your browser.
 
 **2. Create the config file**
 
@@ -137,6 +137,17 @@ COPILOT_QUOTA=300
 copilot-usage          # Shows used/quota in terminal
 copilot-usage --waybar # Shows Waybar JSON
 ```
+
+### Organization-Managed Copilot
+
+If your Copilot license is managed by an organization or enterprise:
+
+1. Log into GitHub in any supported browser (Chrome, Chromium, Brave, Edge, Firefox, or Helium)
+2. Open `https://github.com/settings/copilot/features`
+3. Confirm the page shows the **Premium requests** usage percentage
+4. Run `copilot-usage`
+
+The script will try the personal billing API first, then fall back to reading the usage percentage from the browser-authenticated Copilot settings page, using the same cross-browser cookie discovery as the other providers.
 
 </details>
 

--- a/copilot.py
+++ b/copilot.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 import urllib.request
 import urllib.error
 from datetime import datetime, timezone
 from pathlib import Path
+
+import browser_cookie3
+from curl_cffi import requests
 
 from common import format_eta, format_output, get_cached_or_fetch
 
@@ -18,6 +22,7 @@ COPILOT_ICON = "\uf4b8"   # nf-seti-copilot — same as LazyVim/Neovim Copilot (
 COPILOT_COLOR = "#8b5cf6"
 DEFAULT_QUOTA = 300
 GITHUB_API_BASE = "https://api.github.com"
+COPILOT_FEATURES_URL = "https://github.com/settings/copilot/features"
 
 
 def load_copilot_config(config_path: Path | None = None) -> dict:
@@ -99,9 +104,111 @@ def _fetch_copilot_usage_uncached(token: str) -> dict:
     return {"used": round(used, 1), "raw": usage_data}
 
 
-def get_copilot_usage(token: str) -> dict:
+def _iter_chrome_cookie_files() -> list[Path]:
+    root = Path("~/.config/google-chrome").expanduser()
+    files: list[Path] = []
+    for pattern in ("Default/Cookies", "Profile */Cookies"):
+        files.extend(sorted(root.glob(pattern)))
+    return files
+
+
+def _load_github_cookies(cookie_file: Path) -> dict:
+    cookiejar = browser_cookie3.chrome(cookie_file=str(cookie_file), domain_name="github.com")
+    return {cookie.name: cookie.value for cookie in cookiejar}
+
+
+def _fetch_copilot_usage_from_browser() -> dict:
+    """Fetch Copilot usage percentage from the authenticated Copilot settings page.
+
+    This is a fallback for organization-managed Copilot accounts, where the
+    user billing API does not expose premium request usage. The page itself
+    renders a usage percentage for the currently signed-in account.
+    """
+    errors: list[str] = []
+
+    for cookie_file in _iter_chrome_cookie_files():
+        profile_name = cookie_file.parent.name
+        try:
+            cookies = _load_github_cookies(cookie_file)
+            if not cookies:
+                errors.append(f"{profile_name}: no github.com cookies")
+                continue
+
+            response = requests.get(
+                COPILOT_FEATURES_URL,
+                cookies=cookies,
+                impersonate="chrome",
+                timeout=20,
+                allow_redirects=True,
+            )
+            if response.status_code != 200:
+                errors.append(f"{profile_name}: HTTP {response.status_code}")
+                continue
+
+            html = response.text
+            if 'id="copilot-overages-usage"' not in html:
+                errors.append(f"{profile_name}: no copilot usage section")
+                continue
+
+            section_match = re.search(
+                r'<div id="copilot-overages-usage".*?</li>',
+                html,
+                re.S,
+            )
+            if not section_match:
+                errors.append(f"{profile_name}: usage section parse failed")
+                continue
+
+            pct_match = re.search(r'>\s*(\d+(?:\.\d+)?)%\s*<', section_match.group(0))
+            if not pct_match:
+                errors.append(f"{profile_name}: no usage percentage found")
+                continue
+
+            managed_by = re.search(
+                r'Managed by\s*<a[^>]+href="([^"]+)"[^>]*>([^<]+)</a>',
+                html,
+            )
+            return {
+                "pct": float(pct_match.group(1)),
+                "raw": {
+                    "managed_by_name": managed_by.group(2) if managed_by else None,
+                    "managed_by_href": managed_by.group(1) if managed_by else None,
+                },
+                "source": f"chrome:{profile_name}:copilot-features",
+            }
+        except Exception as exc:
+            errors.append(f"{profile_name}: {exc}")
+
+    detail = "; ".join(errors) if errors else "no Chrome profiles found"
+    raise RuntimeError(
+        "No GitHub Chrome profile exposed Copilot premium request usage. "
+        f"Checked: {detail}"
+    )
+
+
+def _should_fallback_to_browser(error: Exception) -> bool:
+    """Only fall back for user billing API responses that are expected for org-managed Copilot."""
+    message = str(error)
+    return any(code in message for code in ("HTTP 400", "HTTP 403", "HTTP 404"))
+
+
+def get_copilot_usage(token: str | None) -> dict:
     """Fetch Copilot usage with file-based caching (TTL: 60 seconds)."""
-    return get_cached_or_fetch("copilot", lambda: _fetch_copilot_usage_uncached(token))
+    def fetch_browser() -> dict:
+        return get_cached_or_fetch("copilot_browser", _fetch_copilot_usage_from_browser)
+
+    def fetch() -> dict:
+        try:
+            return _fetch_copilot_usage_uncached(token)
+        except Exception as exc:
+            if not _should_fallback_to_browser(exc):
+                raise
+            return fetch_browser()
+
+    if not token:
+        return fetch_browser()
+
+    return get_cached_or_fetch("copilot", fetch)
 
 
 # ==================== Output: CLI / Waybar ====================
@@ -222,40 +329,48 @@ def main() -> None:
     token = config["GITHUB_TOKEN"]
     quota = config["COPILOT_QUOTA"]
 
-    if not token:
-        if args.waybar:
-            print(json.dumps({
-                "text": f"<span foreground='#ff5555'>{COPILOT_ICON} No Token</span>",
-                "tooltip": (
-                    f"No GITHUB_TOKEN found in {args.config}\n"
-                    f"Create a fine-grained PAT with 'Plan (read)' permission:\n"
-                    f"https://github.com/settings/personal-access-tokens/new\n"
-                    f"Then save as GITHUB_TOKEN=github_pat_xxx in {args.config}"
-                ),
-                "class": "critical",
-            }))
-            sys.exit(0)
-        else:
-            print(f"[!] Error: No GITHUB_TOKEN in {args.config}", file=sys.stderr)
-            print(f"    Create a fine-grained PAT with 'Plan (read)' permission:", file=sys.stderr)
-            print(f"    https://github.com/settings/personal-access-tokens/new", file=sys.stderr)
-            sys.exit(1)
-
     try:
         usage = get_copilot_usage(token)
         used = usage.get("used", 0)
+        pct = usage.get("pct")
+        if pct is not None:
+            used = round(quota * float(pct) / 100, 1)
     except Exception as e:
         if args.waybar:
             err_msg = str(e)
-            is_auth = "401" in err_msg or "403" in err_msg or "404" in err_msg
+            is_auth = any(
+                marker in err_msg
+                for marker in (
+                    "401",
+                    "403",
+                    "404",
+                    "No GitHub Chrome profile exposed",
+                    "no github.com cookies",
+                    "no copilot usage section",
+                )
+            )
             short_err = "Auth Err" if is_auth else "Net Err"
             tooltip = f"Error fetching Copilot usage:\n{err_msg}"
-            if "404" in err_msg:
+            if not token:
                 tooltip += (
-                    "\n\nThis endpoint requires a fine-grained PAT with"
+                    f"\n\nNo GITHUB_TOKEN found in {args.config}."
+                    "\nFor personal Copilot, create a fine-grained PAT with"
                     "\n'Plan (read)' permission."
-                    "\nhttps://github.com/settings/personal-access-tokens/new"
+                    "\nFor organization-managed Copilot, log into GitHub in Chrome"
+                    "\nand make sure usage is visible on"
+                    "\nhttps://github.com/settings/copilot/features"
                 )
+            if "No GitHub Chrome profile exposed Copilot premium request usage" in err_msg:
+                tooltip += (
+                    "\n\nFor organization-managed Copilot, make sure you're logged into"
+                    "\nGitHub in a Chrome profile and can see usage on"
+                    "\nhttps://github.com/settings/copilot/features"
+                )
+                if token:
+                    tooltip += (
+                        "\n\nFor personal Copilot, verify your fine-grained PAT has"
+                        "\nUser permissions -> Plan -> Read-only."
+                    )
             print(json.dumps({
                 "text": f"<span foreground='#ff5555'>{COPILOT_ICON} {short_err}</span>",
                 "tooltip": tooltip,
@@ -263,6 +378,11 @@ def main() -> None:
             }))
             sys.exit(0)
         else:
+            if not token:
+                print(f"[!] Error: No GITHUB_TOKEN in {args.config}", file=sys.stderr)
+                print("    For personal Copilot, create a fine-grained PAT with 'Plan (read)' permission.", file=sys.stderr)
+                print("    For organization-managed Copilot, log into GitHub in Chrome and check:", file=sys.stderr)
+                print(f"    {COPILOT_FEATURES_URL}", file=sys.stderr)
             print(f"[!] Critical Error: {e}", file=sys.stderr)
             sys.exit(1)
 

--- a/copilot.py
+++ b/copilot.py
@@ -9,10 +9,9 @@ import urllib.error
 from datetime import datetime, timezone
 from pathlib import Path
 
-import browser_cookie3
 from curl_cffi import requests
 
-from common import format_eta, format_output, get_cached_or_fetch
+from common import format_eta, format_output, get_cached_or_fetch, load_cookies
 
 
 # ==================== Configuration ====================
@@ -54,6 +53,13 @@ def load_copilot_config(config_path: Path | None = None) -> dict:
 
 # ==================== Core Logic: Get Usage ====================
 
+class CopilotHTTPError(RuntimeError):
+    """Raised for HTTP errors from the GitHub API, carrying the numeric status code."""
+    def __init__(self, code: int, body: str) -> None:
+        super().__init__(f"HTTP {code}: {body}")
+        self.code = code
+
+
 def _github_get(url: str, token: str) -> dict | list:
     """Make authenticated GET request to GitHub API."""
     req = urllib.request.Request(
@@ -70,7 +76,7 @@ def _github_get(url: str, token: str) -> dict | list:
             return json.loads(resp.read().decode())
     except urllib.error.HTTPError as e:
         body = e.read().decode()
-        raise RuntimeError(f"HTTP {e.code}: {body}") from e
+        raise CopilotHTTPError(e.code, body) from e
     except urllib.error.URLError as e:
         raise RuntimeError(f"Network error: {e.reason}") from e
 
@@ -104,19 +110,6 @@ def _fetch_copilot_usage_uncached(token: str) -> dict:
     return {"used": round(used, 1), "raw": usage_data}
 
 
-def _iter_chrome_cookie_files() -> list[Path]:
-    root = Path("~/.config/google-chrome").expanduser()
-    files: list[Path] = []
-    for pattern in ("Default/Cookies", "Profile */Cookies"):
-        files.extend(sorted(root.glob(pattern)))
-    return files
-
-
-def _load_github_cookies(cookie_file: Path) -> dict:
-    cookiejar = browser_cookie3.chrome(cookie_file=str(cookie_file), domain_name="github.com")
-    return {cookie.name: cookie.value for cookie in cookiejar}
-
-
 def _fetch_copilot_usage_from_browser() -> dict:
     """Fetch Copilot usage percentage from the authenticated Copilot settings page.
 
@@ -124,72 +117,51 @@ def _fetch_copilot_usage_from_browser() -> dict:
     user billing API does not expose premium request usage. The page itself
     renders a usage percentage for the currently signed-in account.
     """
-    errors: list[str] = []
+    cookies, browser_name = load_cookies("github.com")
 
-    for cookie_file in _iter_chrome_cookie_files():
-        profile_name = cookie_file.parent.name
-        try:
-            cookies = _load_github_cookies(cookie_file)
-            if not cookies:
-                errors.append(f"{profile_name}: no github.com cookies")
-                continue
-
-            response = requests.get(
-                COPILOT_FEATURES_URL,
-                cookies=cookies,
-                impersonate="chrome",
-                timeout=20,
-                allow_redirects=True,
-            )
-            if response.status_code != 200:
-                errors.append(f"{profile_name}: HTTP {response.status_code}")
-                continue
-
-            html = response.text
-            if 'id="copilot-overages-usage"' not in html:
-                errors.append(f"{profile_name}: no copilot usage section")
-                continue
-
-            section_match = re.search(
-                r'<div id="copilot-overages-usage".*?</li>',
-                html,
-                re.S,
-            )
-            if not section_match:
-                errors.append(f"{profile_name}: usage section parse failed")
-                continue
-
-            pct_match = re.search(r'>\s*(\d+(?:\.\d+)?)%\s*<', section_match.group(0))
-            if not pct_match:
-                errors.append(f"{profile_name}: no usage percentage found")
-                continue
-
-            managed_by = re.search(
-                r'Managed by\s*<a[^>]+href="([^"]+)"[^>]*>([^<]+)</a>',
-                html,
-            )
-            return {
-                "pct": float(pct_match.group(1)),
-                "raw": {
-                    "managed_by_name": managed_by.group(2) if managed_by else None,
-                    "managed_by_href": managed_by.group(1) if managed_by else None,
-                },
-                "source": f"chrome:{profile_name}:copilot-features",
-            }
-        except Exception as exc:
-            errors.append(f"{profile_name}: {exc}")
-
-    detail = "; ".join(errors) if errors else "no Chrome profiles found"
-    raise RuntimeError(
-        "No GitHub Chrome profile exposed Copilot premium request usage. "
-        f"Checked: {detail}"
+    response = requests.get(
+        COPILOT_FEATURES_URL,
+        cookies=cookies,
+        impersonate="chrome",
+        timeout=20,
+        allow_redirects=True,
     )
+    if response.status_code != 200:
+        raise RuntimeError(f"{browser_name}: HTTP {response.status_code}")
+
+    html = response.text
+    if 'id="copilot-overages-usage"' not in html:
+        raise RuntimeError(f"{browser_name}: no copilot usage section found")
+
+    section_match = re.search(
+        r'<div id="copilot-overages-usage".*?</li>',
+        html,
+        re.S,
+    )
+    if not section_match:
+        raise RuntimeError(f"{browser_name}: usage section parse failed")
+
+    pct_match = re.search(r'>\s*(\d+(?:\.\d+)?)%\s*<', section_match.group(0))
+    if not pct_match:
+        raise RuntimeError(f"{browser_name}: no usage percentage found")
+
+    managed_by = re.search(
+        r'Managed by\s*<a[^>]+href="([^"]+)"[^>]*>([^<]+)</a>',
+        html,
+    )
+    return {
+        "pct": float(pct_match.group(1)),
+        "raw": {
+            "managed_by_name": managed_by.group(2) if managed_by else None,
+            "managed_by_href": managed_by.group(1) if managed_by else None,
+        },
+        "source": f"{browser_name}:copilot-features",
+    }
 
 
 def _should_fallback_to_browser(error: Exception) -> bool:
     """Only fall back for user billing API responses that are expected for org-managed Copilot."""
-    message = str(error)
-    return any(code in message for code in ("HTTP 400", "HTTP 403", "HTTP 404"))
+    return isinstance(error, CopilotHTTPError) and error.code in (400, 403, 404)
 
 
 def get_copilot_usage(token: str | None) -> dict:
@@ -197,18 +169,15 @@ def get_copilot_usage(token: str | None) -> dict:
     def fetch_browser() -> dict:
         return get_cached_or_fetch("copilot_browser", _fetch_copilot_usage_from_browser)
 
-    def fetch() -> dict:
-        try:
-            return _fetch_copilot_usage_uncached(token)
-        except Exception as exc:
-            if not _should_fallback_to_browser(exc):
-                raise
-            return fetch_browser()
-
     if not token:
         return fetch_browser()
 
-    return get_cached_or_fetch("copilot", fetch)
+    try:
+        return get_cached_or_fetch("copilot", lambda: _fetch_copilot_usage_uncached(token))
+    except Exception as exc:
+        if not _should_fallback_to_browser(exc):
+            raise
+        return fetch_browser()
 
 
 # ==================== Output: CLI / Waybar ====================
@@ -344,8 +313,7 @@ def main() -> None:
                     "401",
                     "403",
                     "404",
-                    "No GitHub Chrome profile exposed",
-                    "no github.com cookies",
+                    "Failed to read cookies for github.com",
                     "no copilot usage section",
                 )
             )
@@ -356,14 +324,15 @@ def main() -> None:
                     f"\n\nNo GITHUB_TOKEN found in {args.config}."
                     "\nFor personal Copilot, create a fine-grained PAT with"
                     "\n'Plan (read)' permission."
-                    "\nFor organization-managed Copilot, log into GitHub in Chrome"
+                    "\nFor organization-managed Copilot, log into GitHub in any browser"
                     "\nand make sure usage is visible on"
                     "\nhttps://github.com/settings/copilot/features"
                 )
-            if "No GitHub Chrome profile exposed Copilot premium request usage" in err_msg:
+            if "Failed to read cookies for github.com" in err_msg or "no copilot usage section" in err_msg:
                 tooltip += (
                     "\n\nFor organization-managed Copilot, make sure you're logged into"
-                    "\nGitHub in a Chrome profile and can see usage on"
+                    "\nGitHub in a browser (Chrome, Chromium, Brave, Firefox, etc.)"
+                    "\nand can see usage on"
                     "\nhttps://github.com/settings/copilot/features"
                 )
                 if token:
@@ -381,7 +350,7 @@ def main() -> None:
             if not token:
                 print(f"[!] Error: No GITHUB_TOKEN in {args.config}", file=sys.stderr)
                 print("    For personal Copilot, create a fine-grained PAT with 'Plan (read)' permission.", file=sys.stderr)
-                print("    For organization-managed Copilot, log into GitHub in Chrome and check:", file=sys.stderr)
+                print("    For organization-managed Copilot, log into GitHub in any browser and check:", file=sys.stderr)
                 print(f"    {COPILOT_FEATURES_URL}", file=sys.stderr)
             print(f"[!] Critical Error: {e}", file=sys.stderr)
             sys.exit(1)


### PR DESCRIPTION
## Summary
- Adds a browser-cookie fallback for organization-managed GitHub Copilot accounts where the personal billing API does not expose premium request usage.
- Keeps the existing fine-grained PAT flow for personal Copilot subscriptions and only falls back on expected billing API responses (`HTTP 400`, `403`, or `404`).
- Documents setup for the organization-managed fallback.

## Details
- The fallback reads `https://github.com/settings/copilot/features` using cookies loaded via `common.load_cookies("github.com")`, which covers Chrome, Chromium, Brave, Edge, Firefox (including XDG path), and Helium.
- Uses a separate cache key (`copilot_browser`) to avoid mixing PAT-based results with browser fallback results. The `copilot` cache only ever holds PAT-derived data.
- `CopilotHTTPError` carries the numeric HTTP status code so fallback triggering is based on `exc.code in (400, 403, 404)` rather than substring matching.
- Browser fallback errors are classified as auth/profile issues in Waybar so users get actionable guidance.

## Limitations
- The fallback parses the percentage rendered by GitHub's settings page, so it is less stable than the official billing API and may need updates if GitHub changes that page markup.
- The fallback reports usage percentage; request counts are derived from the configured `COPILOT_QUOTA`.

## Testing
- `python -m py_compile copilot.py`
- `git diff --check`
- `python copilot.py`
- `python copilot.py --waybar`